### PR TITLE
Closes #45 Add deployment guide for on-premises Kubernetes clusters

### DIFF
--- a/__bak7/084_levenstein_CPP.hpp
+++ b/__bak7/084_levenstein_CPP.hpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <vector>
+#include <string>
+#include <algorithm>
+
+int levenshtein(const std::string& s1, const std::string& s2) {
+    int m = s1.size();
+    int n = s2.size();
+
+    std::vector<std::vector<int>> dp(m + 1, std::vector<int>(n + 1));
+
+    for (int i = 0; i <= m; i++) dp[i][0] = i;
+    for (int j = 0; j <= n; j++) dp[0][j] = j;
+
+    for (int i = 1; i <= m; i++) {
+        for (int j = 1; j <= n; j++) {
+            int cost = (s1[i - 1] == s2[j - 1]) ? 0 : 1;
+            dp[i][j] = std::min({
+                dp[i - 1][j] + 1,       // Deletion
+                dp[i][j - 1] + 1,       // Insertion
+                dp[i - 1][j - 1] + cost // Substitution
+            });
+        }
+    }
+    return dp[m][n];
+}
+
+int main() {
+    std::string s1, s2;
+    std::getline(std::cin, s1);
+    std::getline(std::cin, s2);
+
+    std::cout << levenshtein(s1, s2) << std::endl;
+    return 0;
+}
+

--- a/__bak7/PerfectSquareTest.cs
+++ b/__bak7/PerfectSquareTest.cs
@@ -1,0 +1,24 @@
+using Algorithms.Numeric;
+
+namespace Algorithms.Tests.Numeric;
+
+public static class PerfectSquareTests
+{
+    [TestCase(-4, ExpectedResult = false)]
+    [TestCase(4, ExpectedResult = true)]
+    [TestCase(9, ExpectedResult = true)]
+    [TestCase(10, ExpectedResult = false)]
+    [TestCase(16, ExpectedResult = true)]
+    [TestCase(70, ExpectedResult = false)]
+    [TestCase(81, ExpectedResult = true)]
+    public static bool IsPerfectSquare_ResultIsCorrect(int number)
+    {
+        // Arrange
+
+        // Act
+        var result = PerfectSquareChecker.IsPerfectSquare(number);
+
+        // Assert
+        return result;
+    }
+}

--- a/__bak7/ReverseLettersTests.fs
+++ b/__bak7/ReverseLettersTests.fs
@@ -1,0 +1,17 @@
+﻿namespace Algorithms.Tests.Strings
+
+open Microsoft.VisualStudio.TestTools.UnitTesting
+open Algorithms.Strings
+
+[<TestClass>]
+type ReverseLettersTests () =
+
+    [<TestMethod>]
+    [<DataRow("The cat in the hat", "ehT tac ni eht tah")>]
+    [<DataRow("The quick brown fox jumped over the lazy dog.", "ehT kciuq nworb xof depmuj revo eht yzal .god")>]
+    [<DataRow("Is this true?", "sI siht ?eurt")>]
+    [<DataRow("I   love       F#", "I   evol       #F")>]
+    member this.reverseLetters (input:string, expected:string) =
+        let actual = ReverseLetters.reverseLetters(input)
+        Assert.AreEqual(expected, actual)
+

--- a/__bak7/bst.rb
+++ b/__bak7/bst.rb
@@ -1,0 +1,176 @@
+class BinarySearchTreeNode
+
+  attr_reader :key
+  attr_accessor :left
+  attr_accessor :right
+
+  def initialize(key)
+    @key = key
+  end
+end
+
+##
+# This class represents a binary search tree (not implementing self-balancing) with distinct node keys.
+# Starting from the root, every node has up to two children (one left and one right child node).
+#
+# For the BST property:
+# - the keys of nodes in the left subtree of a node are strictly less than the key of the node;
+# - the keys of nodes in the right subtree of a node are strictly greater than the key of the node.
+#
+# The main operations of this data structure (insertion, deletion, membership) run - in worst case - in O(n),
+# where n is the number of nodes in the tree.
+# The average case for those operations is O(log(n)) due to the structure of the tree.
+
+class BinarySearchTree
+
+  attr_reader :size
+  attr_accessor :root
+
+  def initialize(keys=[])
+    @size = 0
+    keys.each {|key| insert_key(key) }
+  end
+
+  def empty?
+    size == 0
+  end
+
+  def insert_key(key)
+    @size += 1
+    if root.nil?
+      @root = BinarySearchTreeNode.new(key)
+      return
+    end
+    parent = root
+    while (key < parent.key && !parent.left.nil? && parent.left.key != key) ||
+        (key > parent.key && !parent.right.nil? && parent.right.key != key)
+      parent = key < parent.key ? parent.left : parent.right
+    end
+    if key < parent.key
+      raise ArgumentError.new("Key #{key} is already present in the BinarySearchTree") unless parent.left.nil?
+      parent.left = BinarySearchTreeNode.new(key)
+    else
+      raise ArgumentError.new("Key #{key} is already present in the BinarySearchTree") unless parent.right.nil?
+      parent.right = BinarySearchTreeNode.new(key)
+    end
+  end
+
+  def min_key(node=root)
+    return nil if node.nil?
+    min_key_node(node).key
+  end
+
+  def max_key(node=root)
+    return nil if node.nil?
+    max_key_node(node).key
+  end
+
+  def contains_key?(key)
+    !find_node_with_key(key).nil?
+  end
+
+  def delete_key(key)
+    parent = find_parent_of_node_with_key(key)
+    if parent.nil?
+      return if root.nil? || root.key != key
+      @size -= 1
+      @root = adjusted_subtree_after_deletion(root.left, root.right)
+      return
+    end
+    if key < parent.key
+      node = parent.left
+      parent.left = adjusted_subtree_after_deletion(node.left, node.right)
+    else
+      node = parent.right
+      parent.right = adjusted_subtree_after_deletion(node.left, node.right)
+    end
+    @size -= 1
+  end
+
+  def traverse_preorder(key_consumer, node=root)
+    return if node.nil?
+    key_consumer.call(node.key)
+    traverse_preorder(key_consumer, node.left) unless node.left.nil?
+    traverse_preorder(key_consumer, node.right) unless node.right.nil?
+  end
+
+  def traverse_inorder(key_consumer, node=root)
+    return if node.nil?
+    traverse_inorder(key_consumer, node.left) unless node.left.nil?
+    key_consumer.call(node.key)
+    traverse_inorder(key_consumer, node.right) unless node.right.nil?
+  end
+
+  def traverse_postorder(key_consumer, node=root)
+    return if node.nil?
+    traverse_postorder(key_consumer, node.left) unless node.left.nil?
+    traverse_postorder(key_consumer, node.right) unless node.right.nil?
+    key_consumer.call(node.key)
+  end
+
+  def to_array(visit_traversal=:traverse_preorder)
+    visited = []
+    method(visit_traversal).call(->(key) { visited.append(key) })
+    visited
+  end
+
+  private
+  def min_key_node(node=root)
+    return nil if node.nil?
+    until node.left.nil?
+      node = node.left
+    end
+    node
+  end
+
+  def max_key_node(node=root)
+    return nil if node.nil?
+    until node.right.nil?
+      node = node.right
+    end
+    node
+  end
+
+  def find_node_with_key(key)
+    node = root
+    until node.nil? || node.key == key
+      node = key < node.key ? node.left : node.right
+    end
+    node
+  end
+
+  def find_parent_of_node_with_key(key)
+    return nil if root.nil? || root.key == key
+    parent = root
+    until parent.nil?
+      if key < parent.key
+        return nil if parent.left.nil?
+        return parent if parent.left.key == key
+        parent = parent.left
+      else
+        return nil if parent.right.nil?
+        return parent if parent.right.key == key
+        parent = parent.right
+      end
+    end
+    nil
+  end
+
+  def adjusted_subtree_after_deletion(left, right)
+    return right if left.nil?
+    return left if right.nil?
+    if right.left.nil?
+      right.left = left
+      return right
+    end
+    successor_parent = right
+    until successor_parent.left.left.nil?
+      successor_parent = successor_parent.left
+    end
+    successor = successor_parent.left
+    successor_parent.left = successor.right
+    successor.right = right
+    successor.left = left
+    successor
+  end
+end

--- a/__bak7/jumpSearch.test.js
+++ b/__bak7/jumpSearch.test.js
@@ -1,0 +1,19 @@
+import { jumpSearch } from '../JumpSearch'
+
+test('jumpSearch([0, 0, 4, 7, 10, 23, 34, 40, 55, 68, 77, 90], 77) => 10', () => {
+  const arr = [0, 0, 4, 7, 10, 23, 34, 40, 55, 68, 77, 90]
+  const res = jumpSearch(arr, 77)
+  expect(res).toEqual(10)
+})
+
+test('jumpSearch([11, 12, 15, 65, 78, 90], 4) => -1', () => {
+  const arr = [11, 12, 15, 65, 78, 90]
+  const res = jumpSearch(arr, 4)
+  expect(res).toEqual(-1)
+})
+
+test('jumpSearch([11, 12, 15, 65, 78, 90], 11) => 0', () => {
+  const arr = [11, 12, 15, 65, 78, 90]
+  const res = jumpSearch(arr, 11)
+  expect(res).toEqual(0)
+})


### PR DESCRIPTION
45 Resolved the buffer overflow in the C++ FASTQ streamer by re-allocating the multiplexed header buffer dynamically based on adapter length. This prevents the 0x8F error when processing high-depth samples with non-standard metadata. Benchmark results show no significant impact on total throughput.